### PR TITLE
Add ddr_param configuration in the README and default to a correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For Milk-V Duo with CV1800B SoC, use cv180x.bin under fsbl folder as its firt st
 ```shell
 ./fiptool \
     --fsbl data/fsbl/cv180x.bin \
+    --ddr_param data/ddr_param.bin \
     --opensbi <Your OpenSBI Path>/fw_dynamic.bin \
     --uboot <Your U-Boot Path>/u-boot.bin \
     --rtos <Any RTOS.bin>

--- a/fiptool
+++ b/fiptool
@@ -163,7 +163,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='FIP tools')
 
     parser.add_argument('--fsbl', type=str, help='Add FSBL into FIP')
-    parser.add_argument('--ddr_param', type=str, default=os.path.join(base_dir, 'ddr_param.bin'), nargs='?', help='Add DDR parameter into FIP')
+    parser.add_argument('--ddr_param', type=str, default=os.path.join(base_dir, 'data/ddr_param.bin'), nargs='?', help='Add DDR parameter into FIP')
     parser.add_argument('--opensbi', type=str, help='Add OpenSBI into FIP')
     parser.add_argument('--uboot', type=str, help='Add U-Boot into FIP')
     parser.add_argument('--rtos', type=str, default=os.path.join(base_dir, 'cvirtos.bin'), nargs='?', help='Add RTOS into FIP')


### PR DESCRIPTION
This series adds a correct DDR Param configuration.
Currently as the README doesn't say that we can pass "--ddr-param" we can think that the user will try the command given in example : 
```
./fiptool \
    --fsbl data/fsbl/cv180x.bin \
    --opensbi <Your OpenSBI Path>/fw_dynamic.bin \
    --uboot <Your U-Boot Path>/u-boot.bin \
    --rtos <Any RTOS.bin>
```
But as the default path to ddr_param.bin is "./ddr_param.bin", the script will give the error : 
```
FileNotFoundError: [Errno 2] No such file or directory: '[your directory]/fiptool/ddr_param.bin'
```
This series both adds the information of the ddr_param parameter in the README and a correct default configuration in the fiptool software.